### PR TITLE
include LICENSE in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ graft ecos/include
 graft ecos/external/amd/include
 graft ecos/external/ldl/include
 graft ecos/external/SuiteSparse_config
+include LICENSE


### PR DESCRIPTION
Right now, your `LICENSE` file isn't included in the pypi source distributions. This change makes it be included in the files made by `setup.py sdist`.