### PR TITLE
Add aarch64 wheel build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,13 @@ matrix:
         - docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
            PRE_CMD=linux32
+    - sudo: required
+      arch: arm64-graviton2
+      group: edge
+      virt: lxd
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux2014_aarch64
     - os: osx
       env: PYTHON=python3
 

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -4,6 +4,9 @@ set -e -x
 # Install a system package required by our library
 #yum install -y atlas-devel
 
+if [ $(uname -m) == "aarch64" ]; then
+    yum install -y blas-devel lapack-devel
+fi
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     "${PYBIN}/pip" install nose coverage #-r /io/dev-requirements.txt


### PR DESCRIPTION
Add aarch64 wheel build support.
Related to https://github.com/embotech/ecos-python/issues/23 @SteveDiamond Could you please review this PR?