### PR TITLE
switch build-time dependency declaration to PEP 517 and use oldest version of numpy possible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "oldest-supported-numpy",
+    "setuptools",
+    "wheel"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [build-system]
 requires = [
-    "oldest-supported-numpy",
+    "numpy>=1.16,<1.17; python_version=='3.5'",
+    "numpy>=1.16,<1.17; python_version=='3.6'",
+    "numpy>=1.16,<1.17; python_version=='3.7'",
+    "numpy>=1.16,<1.17; python_version=='3.8'",
+    "numpy>=1.19,<1.20; python_version=='3.9'",
     "setuptools",
     "wheel"
 ]

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,9 @@ setup(
     package_dir = {'': 'src'},
     cmdclass = {'build_ext': build_ext},
     ext_modules = [_ecos],
+    setup_requires = [
+        "numpy >= 1.6"
+    ],
     install_requires = [
         "numpy >= 1.6",
         "scipy >= 0.9"

--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,6 @@ setup(
     package_dir = {'': 'src'},
     cmdclass = {'build_ext': build_ext},
     ext_modules = [_ecos],
-    setup_requires = [
-        "numpy >= 1.6"
-    ],
     install_requires = [
         "numpy >= 1.6",
         "scipy >= 0.9"


### PR DESCRIPTION
It is best practice to build against the oldest version of Numpy a package can work with, as binaries compiled with old Numpy versions are binary compatible with newer Numpy versions, but not vice versa. The current setup.py only specifies numpy>=1.16, which means by default pip will use the latest version of numpy if none is already installed. This can lead to install issues, e.g. as displayed in https://github.com/cvxpy/cvxpy/issues/1367. See https://pypi.org/project/oldest-supported-numpy/ for more details (note: we're not able to use this package because we want numpy >= 1.16).