### PR TITLE
add pyproject.toml build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["wheel", "setuptools", "oldest-supported-numpy"]


### PR DESCRIPTION
It is best practice to build against the oldest version of Numpy a package can work with, as binaries compiled with old Numpy versions are binary compatible with newer Numpy versions, but not vice versa. 

With ecos2.0.8 I'm experiencing the same as for example displayed in https://github.com/cvxpy/cvxpy/issues/1367.
See https://pypi.org/project/oldest-supported-numpy/ for more details 