### PR TITLE
Use np.array in test_interface_bb.py

### DIFF
--- a/src/test_interface_bb.py
+++ b/src/test_interface_bb.py
@@ -1,15 +1,16 @@
 from __future__ import print_function
 import ecos
 import numpy as np
-from scipy import *
 import scipy.sparse as sp
 
 c = np.array([-1., -1.])
-h = np.array([ 4., 12., 0. , 0.])
+h = np.array([ 4., 12., 0., 0.])
 bool_idx = [1]
-G = sp.csc_matrix( (array([2.0, 3.0, -1.0, 1.0, 4.0, -1.0]), 
-	array([0, 1, 2, 0, 1, 3]), 
-	array([0, 3, 6])) )  
+G = sp.csc_matrix((
+    np.array([2.0, 3.0, -1.0, 1.0, 4.0, -1.0]),
+	np.array([0, 1, 2, 0, 1, 3]),
+	np.array([0, 3, 6]),
+))
 
 dims = dict()
 dims['l'] = 4
@@ -19,11 +20,13 @@ sol = ecos.solve(c, G, h, dims, verbose=False, mi_verbose=False, int_vars_idx=bo
 print(sol['x'])
 
 c = np.array([-1., -1.])
-h = np.array([ 4., 12., 0. , 0.])
+h = np.array([ 4., 12., 0., 0.])
 bool_idx = []
-G = sp.csc_matrix( (array([2.0, 3.0, -1.0, 1.0, 4.0, -1.0]), 
-	array([0, 1, 2, 0, 1, 3]), 
-	array([0, 3, 6])) )    
+G = sp.csc_matrix((
+    np.array([2.0, 3.0, -1.0, 1.0, 4.0, -1.0]),
+	np.array([0, 1, 2, 0, 1, 3]),
+	np.array([0, 3, 6]),
+))
 
 dims = dict()
 dims['l'] = 4
@@ -33,11 +36,13 @@ sol = ecos.solve(c, G, h, dims, verbose=False, mi_verbose=False, int_vars_idx=bo
 print(sol['x'])
 
 c = np.array([-1., -1.1])
-h = np.array([ 4., 12., 0. , 0.])
+h = np.array([ 4., 12., 0., 0.])
 bool_idx = [1,0]
-G = sp.csc_matrix( (array([2.0, 3.0, -1.0, 1.0, 4.0, -1.0]), 
-	array([0, 1, 2, 0, 1, 3]), 
-	array([0, 3, 6])) )    
+G = sp.csc_matrix((
+    np.array([2.0, 3.0, -1.0, 1.0, 4.0, -1.0]),
+	np.array([0, 1, 2, 0, 1, 3]),
+	np.array([0, 3, 6]),
+))
 
 dims = dict()
 dims['l'] = 4
@@ -50,9 +55,11 @@ print(sol['x'])
 c = np.array([-1., -1.5])
 h = np.array([ 4., 12., 0. , 0.])
 bool_idx = [1]
-G = sp.csc_matrix( (array([2.0, 3.0, -1.0, 1.0, 4.0, -1.0]), 
-	array([0, 1, 2, 0, 1, 3]), 
-	array([0, 3, 6])) )    
+G = sp.csc_matrix((
+    np.array([2.0, 3.0, -1.0, 1.0, 4.0, -1.0]),
+    np.array([0, 1, 2, 0, 1, 3]),
+    np.array([0, 3, 6]),
+))
 
 dims = dict()
 dims['l'] = 4


### PR DESCRIPTION
Tests fail with the following error message (scipy 1.9.1):
```
>   File "/build/source/src/test_interface_bb.py", line 10, in <module>
>     G = sp.csc_matrix( (array([2.0, 3.0, -1.0, 1.0, 4.0, -1.0]),
> NameError: name 'array' is not defined
```

This patch proposes to replace `array` with `np.array`.