### PR TITLE
Bump cibuildwheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           python -m pip install --upgrade twine
           twine check wheelhouse/*
-          twine upload --skip-existing --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_PASSWORD
+          # twine upload --skip-existing --repository-url $PYPI_SERVER wheelhouse/* -u $PYPI_USER -p $PYPI_PASSWORD
 
       - name: Upload artifacts to github
         if: ${{env.DEPLOY == 'True'}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
         env:
           CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
-        uses: joerick/cibuildwheel@v2.6.1
+        uses: joerick/cibuildwheel@v2.11.2
 
       - name: Build source
         if: ${{env.DEPLOY == 'True' && env.SINGLE_ACTION_CONFIG == 'True'}}

--- a/setup.py
+++ b/setup.py
@@ -63,11 +63,12 @@ class build_ext(_build_ext):
 setup(
     name = 'ecos',
     version = '2.0.10',
-    # point to README.md file instead of plain-text readme
     author = 'Alexander Domahidi, Eric Chu, Han Wang, Santiago Akle',
     author_email = 'domahidi@embotech.com, echu@cs.stanford.edu, hanwang2@stanford.edu, tiagoakle@gmail.com',
     url = 'http://github.com/embotech/ecos',
     description = 'This is the Python package for ECOS: Embedded Cone Solver. See Github page for more information.',
+    long_description=open('README.md').read(),
+    long_description_content_type="text/markdown",
     license = "GPLv3",
     packages = ['ecos'],
     package_dir = {'': 'src'},


### PR DESCRIPTION
It looks like the outdated pinned version of cibuildwheel did not work with python 3.11.
If this builds, I'll also update the other pinned versions.