### PR TITLE
fix: zero initialize settings

### DIFF
--- a/src/ecosmodule.c
+++ b/src/ecosmodule.c
@@ -215,8 +215,8 @@ static PyObject *csolve(PyObject* self, PyObject *args, PyObject *kwargs)
   long mi_iterations = -1;
 
   /* Default ECOS settings */
-  settings opts_ecos;
-  settings_bb opts_ecos_bb;
+  settings opts_ecos = {0};
+  settings_bb opts_ecos_bb = {0};
 
   pwork* mywork = NULL;
   ecos_bb_pwork* myecos_bb_work = NULL;


### PR DESCRIPTION
fixes #51

[Since ecos v2.0.8, the integer solver has 3 new settings](https://github.com/embotech/ecos/commit/f0e3c5a6a91168dc1f2653aef72808a1155efc7c). These settings, due to the initialization statements, are set to random values. Furthermore, the library user has no way to provide these settings.

This change make sure there are valid default settings corresponding to the behavior before the introduction of branching strategy and node selection. 

```c
branching_strategy = 0; // BRANCHING_STRATEGY_MOST_INFEASIBLE 
node_selection_method = 0; //BREADTH_FIRST
```