### PR TITLE
Removes 3.7 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, macos-12, windows-2019 ]
-        python-version: [ 3.9, 3.8, "3.10", "3.11", "3.12" ]
+        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, macos-12, windows-2019 ]
-        python-version: [ 3.7, 3.9, "3.10", "3.11", "3.12" ]
+        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
         include:
           - os: ubuntu-20.04
             python-version: 3.8


### PR DESCRIPTION
#55 removed the 3.7 tests, but this removes 3.7 also from the build.